### PR TITLE
Fix get_server_name method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/cmake-build-debug/
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.22)
+project(netguard C)
+
+set(CMAKE_C_STANDARD 11)
+
+include_directories(src)
+
+add_executable(netguard
+        src/android.c
+        src/dhcp.c
+        src/dns.c
+        src/global.h
+        src/icmp.c
+        src/icmp.h
+        src/ip.c
+        src/memory.c
+        src/memory.h
+        src/netguard.c
+        src/netguard.h
+        src/pcap.c
+        src/pcap.h
+        src/platform.h
+        src/session.c
+        src/session.h
+        src/socks5.c
+        src/tcp.c
+        src/tls.c
+        src/udp.c
+        src/udp.h
+        src/util.c
+        src/util.h
+        src/tls.h)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Note: This checklist is a reminder of our shared engineering expectations. 
+The items in Bold are required
+If your PR involves UI changes:
+    1. Upload screenshots or screencasts that illustrate the changes before / after
+    2. Add them under the UI changes section (feel free to add more columns if needed)
+    3. Make sure these changes are tested in API 23 and API 26
+If your PR does not involve UI changes, you can remove the **UI changes** section
+-->
+
+Task/Issue URL: 
+
+### Description
+
+### Steps to test this PR
+
+_Feature 1_
+- [ ]
+- [ ]

--- a/src/netguard.h
+++ b/src/netguard.h
@@ -96,8 +96,6 @@ struct ip6_hdr_pseudo {
 
 // Prototypes
 
-void handle_signal(int sig, siginfo_t *info, void *context);
-
 void *handle_events(void *a);
 
 void report_exit(const struct arguments *args, const char *fmt, ...);
@@ -132,7 +130,7 @@ uint16_t get_default_mss(int version);
 
 int check_tun(const struct arguments *args,
               const struct epoll_event *ev,
-              const int epoll_fd,
+              int epoll_fd,
               int sessions, int maxsessions);
 
 void check_icmp_socket(const struct arguments *args, const struct epoll_event *ev);
@@ -148,7 +146,7 @@ int parse_dns_response(const struct arguments *args, const struct ng_session *se
 
 void check_tcp_socket(const struct arguments *args,
                       const struct epoll_event *ev,
-                      const int epoll_fd);
+                      int epoll_fd);
 
 void sni_resolved(const struct arguments *args, const char *name, const char *daddr);
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203126514402185/f

### Description
When parsing the ClientHello header we made a mistake when advancing through the extensions. We should increase the offset by `extension_len` however we increased the offset by `extensions_len`–which is the length of all extensions.

As we were looking for one particular extention, ie. "server name"–type=0x0000– the crash would happen when the "server name" extension was not the first one.

Incidentally added:
* PR template
* `.gitignore` file 
* `CMakeList` that currently just lists the files but doesn't compile. This is just to little by little prep the library to be developed in isolation

### Steps to test this PR
- [x] In the android repo `cd ~/code/ddg/Android/vpn-network/vpn-network-impl/src/main/cpp/netguard`
- [x] fetch this PR branch, ie. `fix/aitor/atp/get_sni_server_name`
- [x] go back to the Android project root directory
- [x] run `git submodule` and ensure the `vpn-network/vpn-network-impl/src/main/cpp/netguard` submodule points to `ebc033f7c54b3dd32299c189e8b1c0144d39819a` commit, ie. `heads/fix/aitor/atp/get_sni_server_name` branch
- [x] build the android app
- [x] launch app and enable AppTP
- [ ] ensure AppTP blocks as usual when launching apps that attempt to track, ie. speedtest
