### PR TITLE
Block TLS packet rather than SYN packet

### DIFF
--- a/src/netguard.c
+++ b/src/netguard.c
@@ -305,48 +305,6 @@ void log_packet(const struct arguments *args, const packet_t *packet) {
 #endif
 }
 
-
-static jmethodID midSniResolved = NULL;
-
-void sni_resolved(const struct arguments *args, const char *name, const char *daddr) {
-#ifdef PROFILE_JNI
-    float mselapsed;
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
-#endif
-
-    jclass clsService = (*args->env)->GetObjectClass(args->env, args->instance);
-    ng_add_alloc(clsService, "clsService");
-
-    const char *signature = "(Ljava/lang/String;Ljava/lang/String;)V";
-    if (midSniResolved == NULL) {
-        midSniResolved = jniGetMethodID(args->env, clsService, "sniResolved", signature);
-    }
-
-    jstring jname = (*args->env)->NewStringUTF(args->env, name);
-    jstring jresource = (*args->env)->NewStringUTF(args->env, daddr);
-    ng_add_alloc(jname, "jname");
-    ng_add_alloc(jresource, "jresource");
-
-    (*args->env)->CallVoidMethod(args->env, args->instance, midSniResolved, jname, jresource);
-    jniCheckException(args->env);
-
-    (*args->env)->DeleteLocalRef(args->env, jname);
-    (*args->env)->DeleteLocalRef(args->env, jresource);
-    (*args->env)->DeleteLocalRef(args->env, clsService);
-    ng_delete_alloc(jname, __FILE__, __LINE__);
-    ng_delete_alloc(jresource, __FILE__, __LINE__);
-    ng_delete_alloc(clsService, __FILE__, __LINE__);
-
-#ifdef PROFILE_JNI
-    gettimeofday(&end, NULL);
-    mselapsed = (end.tv_sec - start.tv_sec) * 1000.0 +
-                (end.tv_usec - start.tv_usec) / 1000.0;
-    if (mselapsed > PROFILE_JNI)
-        log_print(PLATFORM_LOG_PRIORITY_WARN, "sni_resolved %f", mselapsed);
-#endif
-}
-
 static jmethodID midDnsResolved = NULL;
 static jmethodID midInitRR = NULL;
 jfieldID fidQTime = NULL;

--- a/src/netguard.h
+++ b/src/netguard.h
@@ -148,14 +148,18 @@ void check_tcp_socket(const struct arguments *args,
                       const struct epoll_event *ev,
                       int epoll_fd);
 
-void sni_resolved(const struct arguments *args, const char *name, const char *daddr);
-
-void tls_sni_inspection(const struct arguments *args,
-                        const uint8_t *pkt,
-                        size_t length,
-                        void *daddr,
-                        uint8_t version,
-                        const uint8_t *tcp_payload
+/**
+ * Inspect for SNI header, if found check if domain should be blocked
+ *
+ * @return "0" when SNI header should NOT be blocked, any other value otherwise
+ */
+int is_sni_found_and_blocked(const struct arguments *args,
+                              const uint8_t *pkt,
+                              size_t length,
+                              void *daddr,
+                              uint8_t version,
+                              const uint8_t *tcp_payload,
+                              int uid
 );
 
 jboolean handle_icmp(const struct arguments *args,

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -715,7 +715,10 @@ jboolean handle_tcp(const struct arguments *args,
     }
 
     // intercept TLS
-    tls_sni_inspection(args, pkt, length, daddr, version, payload);
+    if(cur != NULL && is_sni_found_and_blocked(args, pkt, length, daddr, version, payload, cur->tcp.uid)) {
+        // Drop request for SNI domain that should be blocked
+        return 1;
+    }
 
     char flags[10];
     int flen = 0;

--- a/src/tls.c
+++ b/src/tls.c
@@ -23,13 +23,14 @@ static void get_server_name(
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void tls_sni_inspection(
+int is_sni_found_and_blocked(
     const struct arguments *args,
     const uint8_t *pkt,
     size_t length,
     void *daddr,
     uint8_t version,
-    const uint8_t *tcp_payload
+    const uint8_t *tcp_payload,
+    int uid
 ) {
     char dest[INET6_ADDRSTRLEN + 1];
     inet_ntop(version == 4 ? AF_INET : AF_INET6, daddr, dest, sizeof(dest));
@@ -41,12 +42,12 @@ void tls_sni_inspection(
 
     if (strlen(sn) == 0) {
         log_print(PLATFORM_LOG_PRIORITY_INFO, "TLS server name not found");
-        return;
+        return 0;
     }
 
     log_print(PLATFORM_LOG_PRIORITY_INFO, "TLS server %s (%s) found", sn, dest);
 
-    sni_resolved(args, sn, dest);
+    return is_domain_blocked(args, sn, uid);
 }
 
 static void get_server_name(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1203277901387351/f

### Description
We would previously use the SYN packet as a place to decide whether we want to block a request or not.
That had some nuances as described in [this task](https://app.asana.com/0/1202279501986195/1203277901387351/f)

This makes some changes so that the place to decide whether to block a request or not is the TLS handshake instead.

### Steps to test this PR
Tests from https://github.com/duckduckgo/Android/pull/2482