### PR TITLE
Check valid server name UTF-8 encoding

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -125,7 +125,12 @@ void get_server_name(
                         } else {
                             memcpy(server_name, &tls[index], server_name_len);
                             server_name[server_name_len] = 0;
-                            log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS server name (%d bytes) is %s (%s)", server_name_len, server_name, dest);
+                            if (is_valid_utf8(server_name)) {
+                                log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS server name (%d bytes) is %s (%s)", server_name_len, server_name, dest);
+                            } else {
+                                log_print(PLATFORM_LOG_PRIORITY_WARN, "TLS server name not valid UTF-8: %s (%d bytes)", server_name, server_name_len);
+                                *server_name = 0;
+                            }
                         }
                     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -171,3 +171,59 @@ long long get_ms() {
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec * 1000LL + ts.tv_nsec / 1e6;
 }
+
+static int is10x(int a) {
+    int bit1 = (a >> 7) & 1;
+    int bit2 = (a >> 6) & 1;
+    return (bit1 == 1) && (bit2 == 0);
+}
+
+int is_valid_utf8(const char *str) {
+    int str_len = strlen(str);
+    for (int i = 0; i < str_len; i++) {
+        // 0xxxxxxx
+        int bit1 = (str[i] >> 7) & 1;
+        if (bit1 == 0) continue;
+        // 110xxxxx 10xxxxxx
+        int bit2 = (str[i] >> 6) & 1;
+        if (bit2 == 0) return 0;
+        // 11
+        int bit3 = (str[i] >> 5) & 1;
+        if (bit3 == 0) {
+            // 110xxxxx 10xxxxxx
+            if ((++ i) < str_len) {
+                if (is10x(str[i])) {
+                    continue;
+                }
+                return 0;
+            } else {
+                return 0;
+            }
+        }
+        int bit4 = (str[i] >> 4) & 1;
+        if (bit4 == 0) {
+            // 1110xxxx 10xxxxxx 10xxxxxx
+            if (i + 2 < str_len) {
+                if (is10x(str[i + 1]) && is10x(str[i + 2])) {
+                    i += 2;
+                    continue;
+                }
+                return 0;
+            } else {
+                return 0;
+            }
+        }
+        int bit5 = (str[i] >> 3) & 1;
+        if (bit5 == 1) return false;
+        if (i + 3 < str_len) {
+            if (is10x(str[i + 1]) && is10x(str[i + 2]) && is10x(str[i + 3])) {
+                i += 3;
+                continue;
+            }
+            return 0;
+        } else {
+            return 0;
+        }
+    } // for
+    return 1;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -23,4 +23,24 @@ long long get_ms();
 
 const char *strstate(const int state);
 
+/**
+ * @brief Verifies if the provided str is valid UTF-8 encoded.
+ * @return "1" if valid UTF-8, "0" otherwise.
+ *
+ * A character in UTF8 can be from 1 to 4 bytes long, subjected to the following rules:
+ * - For 1-byte character, the first bit is a 0, followed by its unicode code.
+ * - For n-bytes character, the first n-bits are all one’s, the n+1 bit is 0, followed by n-1 bytes with most significant 2 bits being 10.
+ * The following table summarizes the range of UTF-8 encoding for different n.
+ *
+ *  +---------------------+-------------------------------------+
+ *  | Char. number range  |        UTF-8 octet sequence         |
+ *  +---------------------+-------------------------------------+
+ *  | 0000 0000-0000 007F | 0xxxxxxx                            |
+ *  | 0000 0080-0000 07FF | 110xxxxx 10xxxxxx                   |
+ *  | 0000 0800-0000 FFFF | 1110xxxx 10xxxxxx 10xxxxxx          |
+ *  | 0001 0000-0010 FFFF | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx |
+ *  +---------------------+-------------------------------------+
+ */
+int is_valid_utf8(const char *str);
+
 #endif // UTIL_H


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203441773629419/f

### Description
When inspecting the SNI header and server name is found, verify its encoding is a valid UTF-8 before attempting to pass it through JNI bridge for tracker blocking

UTF-8 is defined as follows:

A character in UTF8 can be from 1 to 4 bytes long, subjected to the following rules:
- For 1-byte character, the first bit is a 0, followed by its unicode code.
- For n-bytes character, the first n-bits are all one’s, the n+1 bit is 0, followed by n-1 bytes with most significant 2 bits being 10.
The following table summarizes the range of UTF-8 encoding for different n.

```
 +---------------------+-------------------------------------+
 | Char. number range  |        UTF-8 octet sequence         |
 +---------------------+-------------------------------------+
 | 0000 0000-0000 007F | 0xxxxxxx                            |
 | 0000 0080-0000 07FF | 110xxxxx 10xxxxxx                   |
 | 0000 0800-0000 FFFF | 1110xxxx 10xxxxxx 10xxxxxx          |
 | 0001 0000-0010 FFFF | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx |
 +---------------------+-------------------------------------+
```

### Steps to test this PR
Smoke tests for AppTP

I have checked in Moto G devices that previous crashes due to invalid encoding are now prolerly detected/handled
