### PR TITLE
Publish to maven central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'duckduckgo/netguard' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Setup gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Upload Artifacts
+        run: cd ./android;./gradlew clean publish --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ARTIFACT_SIGNING_KEY_ID }}

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,16 @@
+Netguard Android
+===============
+Android wrapper for netguard native library. Published as an AAR file into maven.
+
+Download
+--------
+
+```groovy
+implementation 'com.duckduckgo.netguard:netguard-android:<latest-version>'
+```
+
+Snapshots of the development version are available in [Sonatype's `snapshots` repository](https://s01.oss.sonatype.org/content/repositories/snapshots).
+
+License
+-------
+See [LICENSE](https://github.com/duckduckgo/netguard/blob/main/LICENSE)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,56 +1,51 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id "com.vanniktech.maven.publish" version "0.23.1"
 }
 
-apply plugin: 'maven-publish'
+//apply plugin: 'maven-publish'
 
-//def githubProperties = new Properties()
-//githubProperties.load(new FileInputStream(rootProject.file("github.properties")))
-
-// Place the version of your library here
 def getVersionName = { ->
-    return "1.0.0"
+    return getProperty("VERSION_NAME")
 }
 
-// Add the name of your library here
-def getArtifactId = { ->
-    return "ddg-android-netguard-release"
-}
+import com.vanniktech.maven.publish.SonatypeHost
 
-// Add the group ID of your library here
-def getGroupId = { ->
-    return "com.duckduckgo.mobile.android"
-}
+mavenPublishing {
+    // publishing to https://s01.oss.sonatype.org
+    publishToMavenCentral(SonatypeHost.S01)
 
-// Prepare URL of maven package.
-def getGitHubUrl = { ->
-    return "https://maven.pkg.github.com/duckduckgo/netguard"
-}
+    signAllPublications()
 
-publishing {
-    publications {
-        bar(MavenPublication) {
-            groupId getGroupId()
-            artifactId getArtifactId()
-            version getVersionName()
-            // Place the path of your artifact here
-            artifact("$buildDir/outputs/aar/${getArtifactId()}.aar")
+    coordinates("com.duckduckgo.netguard", "netguard-android", "${getVersionName}")
+
+    pom {
+        name = "DDG Netguard"
+        description = "DuckDuckGo networking library."
+        inceptionYear = "2022"
+        url = "https://github.com/duckduckgo/netguard"
+        licenses {
+            license {
+                name = "GNU General Public License v.3"
+                url = "https://github.com/duckduckgo/netguard/blob/main/LICENSE"
+                distribution = "https://github.com/duckduckgo/netguard/blob/main/LICENSE"
+            }
+        }
+        developers {
+            developer {
+                id = "duckduckgo"
+                name = "DuckDuckGo"
+                url = "https://github.com/duckduckgo/"
+            }
+        }
+        scm {
+            url = "https://github.com/duckduckgo/netguard"
+            connection = "scm:git:git://github.com/duckduckgo/netguard.git"
+            developerConnection = "scm:git:ssh://git@github.com:duckduckgo/netguard.git"
         }
     }
-//    repositories {
-//        maven {
-//            name = "GitHubPackages"
-//
-//            url = uri(getGitHubUrl())
-//            credentials {
-//                username = githubProperties['gpr.usr'] ?: System.getenv("GPR_USER")
-//                password = githubProperties['gpr.key'] ?: System.getenv("GPR_API_KEY")
-//            }
-//        }
-//    }
 }
-
 
 android {
     compileSdk 32
@@ -60,7 +55,7 @@ android {
         targetSdk 32
         versionCode 1
         versionName "1.0.0"
-        project.archivesBaseName = "ddg-android-netguard"
+        project.archivesBaseName = "ddg-android-netguard-${getVersionName}"
         setProperty("archivesBaseName", "${archivesBaseName}")
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+VERSION_NAME=1.1.0-SNAPSHOT
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,0 @@
-jdk:
-  - openjdk11
-install:
-   - echo "Running a custom install command"
-   - cd android
-   - ./gradlew clean assemble publishBarPublicationToMavenLocal


### PR DESCRIPTION
Task/Issue URL: 

### Description
Add workflow to publish on maven.
The github workflow will be triggered on main branch on push.
* if the version in gradle.properties is a -SNAPSHOT version it will publish to [sonatype snapthos](https://s01.oss.sonatype.org/content/repositories/snapshots/)
* otherwise it will publish a release version

The proper secrets have been setup in this repo so that the workflow succeeds.

### Steps to test this PR
The https://github.com/duckduckgo/netguard/actions/runs/3923944104 succeeds