### PR TITLE
Add safeguards to TLS extension parsing

### DIFF
--- a/src/netguard/tls.c
+++ b/src/netguard/tls.c
@@ -67,7 +67,7 @@ void get_server_name(
                 // Extract host from ClientHello SNI extension header
 
                 // this skips the TLS header, time and Client Random - and starts with the session ID length
-                uint8_t index = 43;
+                uint32_t index = 43;
                 uint8_t session_id_len = tls[index++];
                 index += session_id_len;
 
@@ -86,10 +86,10 @@ void get_server_name(
                     // Extension headers found
                     log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS ClientHello extensions found");
 
-                    uint16_t searched = 0;
+                    uint32_t searched = 0;
                     uint8_t found = 0;
 
-                    while (searched < extensions_len && index < length) {
+                    while (searched < extensions_len && index + 2 < length) {
                         uint16_t extension_type = (tls[index] << 8 & 0xFF00) + (tls[index + 1] & 0x00FF);
                         index += 2;
 
@@ -100,6 +100,10 @@ void get_server_name(
                             break;
                         } else {
                             log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS extension type %d", extension_type);
+
+                            if (index + 1 >= length) {
+                                break;
+                            }
 
                             uint16_t extension_len = (tls[index] << 8 & 0xFF00) + (tls[index + 1] & 0x00FF);
                             index += 2;


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205417864899546/f

### Description
Fix potential for an infinite loop in TLS extension parsing due to unsinged integer wraps.

### Steps to test this PR
- [ ] from this branch, publish the library to maven local ie. `./gradlew clean assemble publishToMavenLocal`
- [ ] In the DDG android app apply the following path
```diff
Subject: [PATCH] Maven local use
---
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/build.gradle	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -40,6 +40,7 @@
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
Index: versions.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/versions.properties b/versions.properties
--- a/versions.properties	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/versions.properties	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -55,7 +55,7 @@
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.0
+version.com.duckduckgo.netguard..netguard-android=1.7.0-SNAPSHOT
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 
```
- [ ] build DDG app
- [ ] AppTP smoke tests