### PR TITLE
Fix crash in get_server_name

### DIFF
--- a/src/netguard/tls.c
+++ b/src/netguard/tls.c
@@ -59,7 +59,7 @@ void get_server_name(
         } else if (content_type == TLS_TYPE_HANDSHAKE_RECORD) { // content type handshake
             // handshake packet type
             uint16_t tls_handshake_size = (tls[3] << 8 & 0xFF00) + (tls[4] & 0x00FF);
-            if (length - (tls - pkt) < tls_handshake_size + 4) {
+            if (length - (tls - pkt) < tls_handshake_size + 5) {
                 log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS header too short");
             } else if (tls[5] == 1) {
                 log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS packet ClientHello msg found");

--- a/src/netguard/tls.c
+++ b/src/netguard/tls.c
@@ -59,7 +59,7 @@ void get_server_name(
         } else if (content_type == TLS_TYPE_HANDSHAKE_RECORD) { // content type handshake
             // handshake packet type
             uint16_t tls_handshake_size = (tls[3] << 8 & 0xFF00) + (tls[4] & 0x00FF);
-            if (length - (tls - pkt) < 5) {
+            if (length - (tls - pkt) < tls_handshake_size + 4) {
                 log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS header too short");
             } else if (tls[5] == 1) {
                 log_print(PLATFORM_LOG_PRIORITY_DEBUG, "TLS packet ClientHello msg found");


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205523868092348/f

### Description
Fix crash due to index passing TLS packet length

### Steps to test this PR
- [ ] from this branch, publish the library to maven local ie. `./gradlew clean assemble publishToMavenLocal`
- [ ] In the DDG android app apply the following path
```diff
Subject: [PATCH] Maven local use
---
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/build.gradle	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -40,6 +40,7 @@
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
Index: versions.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/versions.properties b/versions.properties
--- a/versions.properties	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/versions.properties	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -55,7 +55,7 @@
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.0
+version.com.duckduckgo.netguard..netguard-android=1.7.0-SNAPSHOT
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 
```
- [ ] build DDG app
- [ ] AppTP smoke tests
