### PR TITLE
Do not report TLS parsing error back to JVM

### DIFF
--- a/src/netguard/tls.c
+++ b/src/netguard/tls.c
@@ -19,9 +19,10 @@ int is_sni_found_and_blocked(
 
     int error_code = get_server_name(pkt, length, tls, sn);
 
-    if (error_code < 0) {
-        report_tls_parsing_error(args, error_code);
-    }
+    // TODO do not report errors back for now see https://app.asana.com/0/488551667048375/1205803419871701/f
+//    if (error_code < 0) {
+//        report_tls_parsing_error(args, error_code);
+//    }
     if (strlen(sn) == 0) {
         log_print(PLATFORM_LOG_PRIORITY_INFO, "TLS server name not found");
         return 0;


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205803419871701/f

### Description
see asana

### Steps to test this PR
### Steps to test this PR
- [x] from this branch, publish the library to maven local ie. `./gradlew clean assemble publishToMavenLocal`
- [x] In the DDG android app apply the following path
```diff
Subject: [PATCH] Maven local use
---
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/build.gradle	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -40,6 +40,7 @@
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
Index: versions.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/versions.properties b/versions.properties
--- a/versions.properties	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/versions.properties	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -55,7 +55,7 @@
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.0
+version.com.duckduckgo.netguard..netguard-android=1.7.0-SNAPSHOT
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 
```
- [x] build DDG app
- [x] AppTP smoke tests


