### PR TITLE
Add common-page-size for 16kb page size support

### DIFF
--- a/android/netguard/src/main/cpp/CMakeLists.txt
+++ b/android/netguard/src/main/cpp/CMakeLists.txt
@@ -76,7 +76,7 @@ add_custom_target(libwg-go.so WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../
         ANDROID_PACKAGE_NAME=${ANDROID_PACKAGE_NAME}
         GRADLE_USER_HOME=${GRADLE_USER_HOME}
         CFLAGS=${CMAKE_C_FLAGS}\ -Wno-unused-command-line-argument
-        LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}\ -fuse-ld=gold\ -Wl,-z,max-page-size=16384
+        LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}\ -fuse-ld=gold\ -Wl,-z,max-page-size=16384\ -Wl,-z,common-page-size=16384
         DESTDIR=${OUT_PATH_CMAKE}
         BUILDDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/../generated-src
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1206705314358009

### Description
Add `common-page-size` linker option. Specifies the default alignment (i.e. "common" page size) that the linker should use when placing segments in memory.
Even with max-page-size=16384, not setting `common-page-size=16384`, the linker may still align segments to 4 KB boundaries, leading to overlapping memory protections and crashes.

`max-page-size`: what must not be exceeded
`common-page-size`: what is actually used for alignment


### Steps to test this PR
* Execute the following to build and publish to maven local
```bash
./gradlew clean assemble publishToMavenLocal
```

* in the android repo, apply the following patch
```diff
commit 4a51fdc00e199ec267f200f4b85e1db707f1d7ff
Author: Aitor Viana <aitorvs@gmail.com>
Date:   Sun Jun 4 20:49:52 2023 -0400

    Maven local use

diff --git a/build.gradle b/build.gradle
index c8bd2d0e8..8d25d535e 100644
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
+//        maven {
+//            url "https://central.sonatype.com/repository/maven-snapshots/"
+//        }
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
diff --git a/versions.properties b/versions.properties
index 47a6aa36d..72bf043fa 100644
--- a/versions.properties
+++ b/versions.properties
@@ -79,7 +79,7 @@ version.com.airbnb.android..lottie=5.2.0
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.9.0
+version.com.duckduckgo.netguard..netguard-android=1.10.1-SNAPSHOT
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 
```
* Build the Android app, install launch and smoke test
